### PR TITLE
Support empty file and multiple arguments

### DIFF
--- a/pre_commit_hooks/check-comments.sh
+++ b/pre_commit_hooks/check-comments.sh
@@ -17,9 +17,38 @@ if ! command which jq &>/dev/null; then
   exit 1
 fi
 
-if [[ "$(cloc --json "$@" | jq '.SUM.comment')" -eq 0 ]]; then
-  >&2 echo "File $@ contains 0 comments"
-  exit 1
-fi
+has_errors=0
 
-exit 0
+function check_file
+{
+    local file_path="$1"
+    local stats=$(cloc --json "$file_path")
+    if [ -z "$stats" ]
+    then
+        # no stats, empty file?
+        return
+    fi
+
+    local lines_count=$(echo "$stats" | jq '.header.n_lines')
+    if [ "$lines_count" -le 1 ]
+    then
+        # empty file
+        return
+    fi
+
+    local comments_count=$(echo "$stats" | jq '.SUM.comment')
+    if [ "$comments_count" -eq 0 ]
+    then
+        >&2 echo "File $@ contains 0 comments"
+        has_errors=1
+    fi
+
+    # all good!
+    return
+}
+
+for file_path in "$@"
+do
+    check_file "$file_path"
+done
+exit $has_errors


### PR DESCRIPTION
- if multiple file paths are passed as arguments, check each one
  independently
- do not throw an error on empty files or files with <= 1 line
